### PR TITLE
feat: [SSB-637] [Sketcher] Rotation of text elements and measured values based on smartphone and tablet orientation

### DIFF
--- a/lib/src/sketch.dart
+++ b/lib/src/sketch.dart
@@ -125,7 +125,7 @@ class _SketchWidgetState extends State<SketchWidget> {
             setState(() => panPosition = null);
             controller.onLongPressEnd(details);
           },
-          onTapUp: (TapUpDetails details) => controller.onTapUp(details.localPosition),
+          onTapUp: (TapUpDetails details) => controller.onTapUp(context, details.localPosition),
           onTapDown: (TapDownDetails details) => controller.onTapDown(details.localPosition),
           child: AspectRatio(
             aspectRatio: initialAspectRatio != null

--- a/lib/src/sketch_controller.dart
+++ b/lib/src/sketch_controller.dart
@@ -486,7 +486,7 @@ class SketchController extends ChangeNotifier {
     _initialTouchPoint = localPosition;
   }
 
-  void onTapUp(Offset localPosition) {
+  void onTapUp(BuildContext context, Offset localPosition) {
     final touchedElement = _getTouchedElementFromAllElements(localPosition);
 
     _clearInitialTouchPoint();
@@ -502,7 +502,8 @@ class SketchController extends ChangeNotifier {
 
         onEditText?.call(textValue).then((value) {
           if (value != null && value.isNotEmpty) {
-            activeElement = TextEle(value, color, position);
+            final orientation = MediaQuery.of(context).orientation;
+            activeElement = TextEle(value, color, position, orientation: orientation);
             notifyListeners();
             _addChangeToHistory();
           }
@@ -537,7 +538,8 @@ class SketchController extends ChangeNotifier {
             final position = Point(localPosition.dx, localPosition.dy);
             onEditText?.call(touchedElement.text).then((value) {
               if (value != null && value.isNotEmpty) {
-                activeElement = TextEle(value, color, position);
+                final orientation = MediaQuery.of(context).orientation;
+                activeElement = TextEle(value, color, position, orientation: orientation);
                 notifyListeners();
                 _addChangeToHistory();
               }


### PR DESCRIPTION
- add context parameter in on tap up function in sketch controller
- supply orientation from mediaquery when editing or adding text


https://github.com/SunlightBro/sketcher/assets/108515113/5122c44a-cde4-4abe-8dc2-a0fc79ff591f


https://github.com/SunlightBro/sketcher/assets/108515113/de561339-e43c-49ca-9af5-adcf9dc650a1

