### PR TITLE
fix: [SSB-624]: Automaticly switch to editMode 

### DIFF
--- a/lib/src/sketch_controller.dart
+++ b/lib/src/sketch_controller.dart
@@ -544,23 +544,21 @@ class SketchController extends ChangeNotifier {
       // On tap up while text mode, call onEditText and
       // either pass the selected text or null if none to create a new text
       case SketchMode.text:
-        final touchedElement =
-            inactiveElements.reversed.firstWhereOrNull((e) => e.getHit(localPosition) != null) as TextEle?;
-
         if (touchedElement != null) {
           inactiveElements = inactiveElements.remove(touchedElement);
           _activeElement = touchedElement;
+          _sketchMode = SketchMode.edit;
+        } else {
+          onEditText?.call(null).then((value) {
+            if (value != null && value.isNotEmpty) {
+              final orientation = MediaQuery.of(context).orientation;
+              final position = Point(localPosition.dx, localPosition.dy);
+              activeElement = TextEle(value, color, position, orientation: orientation);
+              notifyListeners();
+              _addChangeToHistory();
+            }
+          });
         }
-
-        onEditText?.call(touchedElement?.text).then((value) {
-          if (value != null && value.isNotEmpty) {
-            final orientation = MediaQuery.of(context).orientation;
-            final position = Point(localPosition.dx, localPosition.dy);
-            activeElement = TextEle(value, color, position, orientation: orientation);
-            notifyListeners();
-            _addChangeToHistory();
-          }
-        });
       case SketchMode.oval:
       case SketchMode.rect:
         if (touchedElement == null) {

--- a/lib/src/sketch_controller.dart
+++ b/lib/src/sketch_controller.dart
@@ -542,23 +542,27 @@ class SketchController extends ChangeNotifier {
 
     switch (sketchMode) {
       // On tap up while text mode, call onEditText and
-      // either pass the selected text or null if none to create a new text
+      // either pass the selected text + switch to editMode or null if none to create a new text
       case SketchMode.text:
+        String? editText = null;
         if (touchedElement != null) {
           inactiveElements = inactiveElements.remove(touchedElement);
           _activeElement = touchedElement;
           _sketchMode = SketchMode.edit;
-        } else {
-          onEditText?.call(null).then((value) {
-            if (value != null && value.isNotEmpty) {
-              final orientation = MediaQuery.of(context).orientation;
-              final position = Point(localPosition.dx, localPosition.dy);
-              activeElement = TextEle(value, color, position, orientation: orientation);
-              notifyListeners();
-              _addChangeToHistory();
-            }
-          });
+          if (touchedElement is TextEle) {
+            editText = touchedElement.text;
+          }
         }
+        onEditText?.call(editText).then((value) {
+          if (value != null && value.isNotEmpty) {
+            final orientation = MediaQuery.of(context).orientation;
+            final position = Point(localPosition.dx, localPosition.dy);
+            activeElement = TextEle(value, color, position, orientation: orientation);
+            notifyListeners();
+            _addChangeToHistory();
+          }
+        });
+        break;
       case SketchMode.oval:
       case SketchMode.rect:
         if (touchedElement == null) {

--- a/lib/src/sketch_controller.dart
+++ b/lib/src/sketch_controller.dart
@@ -544,15 +544,14 @@ class SketchController extends ChangeNotifier {
       // On tap up while text mode, call onEditText and
       // either pass the selected text + switch to editMode or null if none to create a new text
       case SketchMode.text:
-        String? editText = null;
+        String? editText;
         if (touchedElement != null) {
-          inactiveElements = inactiveElements.remove(touchedElement);
-          _activeElement = touchedElement;
           _sketchMode = SketchMode.edit;
           if (touchedElement is TextEle) {
             editText = touchedElement.text;
           }
         }
+
         onEditText?.call(editText).then((value) {
           if (value != null && value.isNotEmpty) {
             final orientation = MediaQuery.of(context).orientation;
@@ -562,7 +561,6 @@ class SketchController extends ChangeNotifier {
             _addChangeToHistory();
           }
         });
-        break;
       case SketchMode.oval:
       case SketchMode.rect:
         if (touchedElement == null) {


### PR DESCRIPTION
Related to this [ticket.](https://feilfeilfeil.atlassian.net/jira/software/projects/SSB/boards/409?selectedIssue=SSB-624)

* when clicking on existing text it changes to editMode 
* else create a new Text

BEFORE:
[

https://github.com/SunlightBro/sketcher/assets/63294368/ab98573f-5506-4ef0-bfd2-d6ad7c96d0b4

]

AFTER (UPDATED):
[

https://github.com/SunlightBro/sketcher/assets/63294368/6cf47952-1d18-48cc-a542-dfd43991c1c5

]
